### PR TITLE
Issue #17 - Fix library compatibility

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-composeVector = "0.2.0"
+composeVector = "0.2.1"
 kotlin = "2.0.0"
 gradle-android = "8.7.0"
 kotest = "5.9.0"

--- a/plugin/src/main/kotlin/io/github/irgaly/compose/vector/plugin/ComposeVectorPlugin.kt
+++ b/plugin/src/main/kotlin/io/github/irgaly/compose/vector/plugin/ComposeVectorPlugin.kt
@@ -1,6 +1,6 @@
 package io.github.irgaly.compose.vector.plugin
 
-import com.android.build.api.variant.ApplicationAndroidComponentsExtension
+import com.android.build.api.variant.AndroidComponentsExtension
 import com.android.build.gradle.BaseExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -99,11 +99,15 @@ class ComposeVectorPlugin : Plugin<Project> {
      */
     private fun Project.executeOnFinalize(block: () -> Unit) {
         var hasAndroid = false
-        listOf("com.android.application", "com.android.library").forEach { pluginId ->
+
+        setOf(
+            "com.android.application",
+            "com.android.library",
+        ).forEach { pluginId ->
             pluginManager.withPlugin(pluginId) {
                 hasAndroid = true
-                extensions.configure<ApplicationAndroidComponentsExtension> {
-                    finalizeDsl {
+                extensions.configure(type = AndroidComponentsExtension::class) { extension ->
+                    extension.finalizeDsl {
                         block()
                     }
                 }


### PR DESCRIPTION
ApplicationAndroidComponentsExtension の代わりに共通の AndroidComponentsExtension に対して設定することで、Android ライブラリプロジェクトとの互換性を修正してください。

---

Fix compatibility with Android Library projects by configuring against common type `AndroidComponentsExtension` instead of `ApplicationAndroidComponentsExtension`.